### PR TITLE
Document macOS-only local workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.pyc
+index/*.index
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
-# Unhackathon-LLM
+# Unhackathon RAG Starter
+
+A minimal retrieval-augmented generation (RAG) demo that builds a FAISS index over the `.txt` and `.pdf` files in `docs/`, retrieves the most relevant chunks, and asks a hosted LLM on Hugging Face Inference API to answer your question strictly from that context.
+
+This branch is tuned for **local debugging on macOS** using a command-line workflow. There are no deployment instructions; everything runs on your machine while still calling the hosted Hugging Face Inference API for generation.
+
+## Features
+- CPU-only workflow with `sentence-transformers` embeddings (`intfloat/e5-small-v2`).
+- Chunking (~180 words with overlap) and FAISS inner-product search.
+- Command-line interface that cites sources and can display retrieved passages for inspection.
+- Hosted generation via Hugging Face Inference API (`Qwen/Qwen2.5-1.5B-Instruct` by default).
+
+---
+
+## 1. Local Setup (macOS)
+
+### Prerequisites
+- Python 3.10+
+- Hugging Face Inference API token with access to the chosen model.
+
+### Create and Activate a Virtual Environment
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### Prepare Your Documents
+1. Place `.txt` and `.pdf` files inside `docs/`.
+2. For a quick smoke test, create `docs/topic.txt` with a few sentences.
+
+### Build the FAISS Index
+```bash
+python build_index.py
+```
+This writes `index/faiss.index` and `index/chunks.json`.
+
+### Set Hugging Face Credentials
+Export your token (and optionally choose a different model) in the same shell session:
+```bash
+export HF_TOKEN="hf_your_token_here"
+export HF_MODEL="Qwen/Qwen2.5-1.5B-Instruct"  # optional override
+```
+Check that the variables are set before running the CLI:
+```bash
+echo $HF_TOKEN
+```
+
+> **Note:** Some hosted models only expose a chat/completions endpoint. The app automatically retries with chat when necessary, but ensure the model you set in `HF_MODEL` is available through the Hugging Face Inference API.
+
+### Run the CLI Debug Assistant
+Ask a question inline:
+```bash
+python app.py --question "What does the topic document mention?"
+```
+
+Or enter the question interactively and inspect the retrieved context:
+```bash
+python app.py --show-context
+```
+
+The script prints the answer, source list, and (optionally) the retrieved passages so you can debug embedding, retrieval, and prompting issues without spinning up a UI.
+
+---
+
+## Troubleshooting
+- **"No .txt or .pdf files"**: Add at least one text file to `docs/` before running `build_index.py`.
+- **"No chunks produced"**: PDF pages without extractable text may be scanned images; try providing a plain text file.
+- **Weak or missing citations**: Re-run the query with a higher `--top-k` value or rebuild the index with a larger chunk size.
+- **HF errors / 401**: Confirm that `HF_TOKEN` has access to the requested model.
+- **404 when calling the model**: Check the spelling of `HF_MODEL` and make sure the model repo (e.g. `microsoft/Phi-3-mini-4k-instruct`) is public or shared with your token. Private or gated models require a token with permission.
+- **"Model not supported for task text-generation"**: The app automatically retries using the chat completion API. If it persists, pick a chat-capable hosted model (e.g. `Qwen/Qwen2.5-1.5B-Instruct`) or verify the model's Inference API tasks.
+- **Timeouts**: Use a smaller model via `HF_MODEL` or retry later; hosted inference endpoints can be busy.
+
+Enjoy building on this RAG starter locally!

--- a/app.py
+++ b/app.py
@@ -1,0 +1,365 @@
+"""Command-line interface for asking questions against the local FAISS index."""
+
+import argparse
+import json
+import os
+import sys
+from functools import lru_cache
+from typing import List, Tuple
+
+import faiss
+import numpy as np
+from huggingface_hub import InferenceClient
+from requests.exceptions import HTTPError
+from sentence_transformers import SentenceTransformer
+
+INDEX_DIR = "index"
+EMBED_MODEL = "intfloat/e5-small-v2"
+DEFAULT_HF_MODEL = "Qwen/Qwen2.5-1.5B-Instruct"
+
+SYSTEM_PROMPT = (
+    "You answer ONLY using the provided CONTEXT. "
+    "If the answer is not present, say: 'I don't know based on the provided sources.' "
+    "Cite sources as [#] matching the order of the context items."
+)
+
+HF_TOKEN = os.getenv("HF_TOKEN")
+HF_MODEL = os.getenv("HF_MODEL", DEFAULT_HF_MODEL)
+
+
+class MissingCredentialError(RuntimeError):
+    """Raised when the HF token is missing."""
+
+
+@lru_cache(maxsize=1)
+def load_assets(
+    index_dir: str,
+    embed_model: str,
+    hf_model: str,
+    hf_token: str,
+) -> Tuple[faiss.Index, List[dict], SentenceTransformer, InferenceClient]:
+    if not hf_token:
+        raise MissingCredentialError(
+            "HF_TOKEN is required. Set it as an environment variable or pass --hf-token."
+        )
+
+    index_path = os.path.join(index_dir, "faiss.index")
+    chunks_path = os.path.join(index_dir, "chunks.json")
+
+    if not os.path.exists(index_path):
+        raise FileNotFoundError(
+            f"Missing FAISS index at {index_path}. Build it via `python build_index.py`."
+        )
+    if not os.path.exists(chunks_path):
+        raise FileNotFoundError(
+            f"Missing chunk metadata at {chunks_path}. Rebuild with `python build_index.py`."
+        )
+
+    idx = faiss.read_index(index_path)
+    with open(chunks_path, "r", encoding="utf-8") as f:
+        chunks = json.load(f)
+    emb = SentenceTransformer(embed_model)
+    client = InferenceClient(model=hf_model, token=hf_token, timeout=60)
+    return idx, chunks, emb, client
+
+
+def embed_query(emb: SentenceTransformer, q: str) -> np.ndarray:
+    v = emb.encode([f"query: {q}"], normalize_embeddings=True)
+    return np.asarray(v, dtype="float32")
+
+
+def retrieve(
+    idx: faiss.Index, chunks: List[dict], emb: SentenceTransformer, q: str, k: int = 4
+) -> Tuple[List[str], List[str]]:
+    qv = embed_query(emb, q)
+    scores, ids = idx.search(qv, k)
+    picks = [pid for pid in ids[0].tolist() if 0 <= pid < len(chunks)]
+    ctx_texts, labels = [], []
+    for rank, i in enumerate(picks, start=1):
+        c = chunks[i]
+        ctx_texts.append(c["text"])
+        label = f"[{rank}] {c['source']}" + (f" p.{c['page']}" if c['page'] else "")
+        labels.append(label)
+    return ctx_texts, labels
+
+
+def build_context_block(ctx_texts: List[str]) -> str:
+    return "\n\n".join(f"{i + 1}. {t}" for i, t in enumerate(ctx_texts))
+
+
+def make_prompt(question: str, ctx_block: str) -> str:
+    return (
+        f"{SYSTEM_PROMPT}\n\nQuestion:\n{question}\n\nCONTEXT:\n{ctx_block}\n\nAnswer:"
+    )
+
+
+def _extract_error_snippet(err: HTTPError) -> str:
+    snippet = str(err) or ""
+    response = getattr(err, "response", None)
+    payload = None
+    if response is not None:
+        try:
+            payload = response.json()
+        except Exception:
+            payload = None
+        if isinstance(payload, dict):
+            detail = payload.get("error") or payload.get("message") or payload.get("detail")
+            if isinstance(detail, str):
+                return detail
+        text = getattr(response, "text", None)
+        if isinstance(text, str) and text.strip():
+            snippet = text.strip()
+    return snippet
+
+
+def _is_task_mismatch_error(err: HTTPError) -> bool:
+    snippet = _extract_error_snippet(err)
+    if isinstance(snippet, str) and "not supported for task" in snippet.lower():
+        return True
+    text = str(err)
+    return isinstance(text, str) and "not supported for task" in text.lower()
+
+
+def _coerce_chat_content(output) -> str:
+    choices = getattr(output, "choices", None)
+    if isinstance(choices, list) and choices:
+        first = choices[0]
+        message = getattr(first, "message", None)
+        if message is None and isinstance(first, dict):
+            message = first.get("message")
+        content = None
+        if message is not None:
+            if isinstance(message, dict):
+                content = message.get("content")
+            else:
+                content = getattr(message, "content", None)
+        if not content and isinstance(first, dict):
+            content = first.get("content")
+        if isinstance(content, list):
+            content = "".join(str(part) for part in content)
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+    if isinstance(output, dict):
+        dict_choices = output.get("choices")
+        if isinstance(dict_choices, list) and dict_choices:
+            first = dict_choices[0]
+            if isinstance(first, dict):
+                message = first.get("message")
+                if isinstance(message, dict):
+                    content = message.get("content")
+                    if isinstance(content, str) and content.strip():
+                        return content.strip()
+                content = first.get("content")
+                if isinstance(content, str) and content.strip():
+                    return content.strip()
+    generated = getattr(output, "generated_text", None)
+    if isinstance(generated, str) and generated.strip():
+        return generated.strip()
+    return ""
+
+
+def _call_chat_completion(
+    client: InferenceClient, question: str, ctx_block: str
+) -> str:
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": f"Question:\n{question}\n\nCONTEXT:\n{ctx_block}\n\nAnswer:",
+        },
+    ]
+    output = client.chat_completion(
+        messages=messages,
+        max_tokens=220,
+        temperature=0.2,
+    )
+    content = _coerce_chat_content(output)
+    if not content:
+        raise ValueError("Empty response from chat completion.")
+    return content
+
+
+def generate_answer(
+    client: InferenceClient, question: str, ctx_texts: List[str]
+) -> str:
+    ctx_block = build_context_block(ctx_texts)
+    prompt = make_prompt(question, ctx_block)
+    try:
+        out = client.text_generation(
+            prompt,
+            max_new_tokens=220,
+            temperature=0.2,
+            do_sample=False,
+            return_full_text=False,
+        )
+        return out.strip()
+    except HTTPError as err:
+        if not _is_task_mismatch_error(err):
+            raise
+        chat_answer = _call_chat_completion(client, question, ctx_block)
+        return chat_answer.strip()
+
+
+def _format_hf_http_error(err: HTTPError) -> Tuple[str, str | None]:
+    """Return a concise error message and optional hint for HTTP errors."""
+    response = getattr(err, "response", None)
+    base = str(err).strip() or "Hugging Face Inference API request failed."
+    detail = None
+    status = None
+
+    if response is not None:
+        status = getattr(response, "status_code", None)
+        try:
+            payload = response.json()
+        except Exception:
+            payload = None
+
+        if isinstance(payload, dict):
+            detail = payload.get("error") or payload.get("message") or payload.get("detail")
+        elif payload is None and hasattr(response, "text"):
+            text = response.text.strip()
+            if text and text != base:
+                detail = text
+
+    hint = None
+    if status == 404:
+        hint = (
+            "Model not found. Double-check the `HF_MODEL` environment variable or ensure "
+            "the model repo is public and accessible with your token."
+        )
+    elif status in {401, 403}:
+        hint = (
+            "Authentication failed. Verify `HF_TOKEN` is set and has access to the model "
+            "(use a token with Inference API permissions)."
+        )
+    elif status == 400 and _is_task_mismatch_error(err):
+        hint = (
+            "The selected model only exposes a chat/completions endpoint. The app will "
+            "retry using chat, but ensure the model supports inference via the hosted API."
+        )
+
+    message = base if detail is None else f"{base} — {detail}"
+    return message, hint
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Query the local FAISS index and ask a hosted Hugging Face model."
+    )
+    parser.add_argument(
+        "question",
+        nargs="*",
+        help="Question to ask. If omitted, the script prompts via stdin.",
+    )
+    parser.add_argument(
+        "-k",
+        "--top-k",
+        type=int,
+        default=4,
+        help="Number of chunks to retrieve (default: 4).",
+    )
+    parser.add_argument(
+        "--show-context",
+        action="store_true",
+        help="Print the retrieved context passages for inspection.",
+    )
+    parser.add_argument(
+        "--hf-model",
+        help="Override the Hugging Face model ID (defaults to env HF_MODEL or configured default).",
+    )
+    parser.add_argument(
+        "--hf-token",
+        help="Override the Hugging Face token (defaults to env HF_TOKEN).",
+    )
+    parser.add_argument(
+        "--index-dir",
+        default=INDEX_DIR,
+        help="Directory containing faiss.index and chunks.json (default: index).",
+    )
+    return parser
+
+
+def _prompt_for_question() -> str:
+    try:
+        return input("Enter your question: ").strip()
+    except EOFError:
+        return ""
+
+
+def _print_sources(labels: List[str]) -> None:
+    if not labels:
+        print("No sources retrieved.")
+        return
+    print("Sources:")
+    for label in labels:
+        print(f" - {label}")
+
+
+def _print_context(ctx_texts: List[str], labels: List[str]) -> None:
+    if not ctx_texts:
+        return
+    print("\n--- Retrieved Passages ---")
+    for label, text in zip(labels, ctx_texts):
+        print(label)
+        print(text)
+        print()
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    question = " ".join(args.question).strip()
+    if not question:
+        question = _prompt_for_question()
+
+    if not question:
+        print("Provide a question via CLI arguments or stdin.", file=sys.stderr)
+        return 1
+
+    hf_token = args.hf_token or HF_TOKEN
+    hf_model = args.hf_model or HF_MODEL
+
+    try:
+        idx, chunks, emb, client = load_assets(args.index_dir, EMBED_MODEL, hf_model, hf_token)
+    except MissingCredentialError as err:
+        print(err, file=sys.stderr)
+        return 2
+    except FileNotFoundError as err:
+        print(err, file=sys.stderr)
+        return 3
+    except Exception as err:  # pragma: no cover - defensive catch for asset loading
+        print(f"Failed to load assets: {err}", file=sys.stderr)
+        return 4
+
+    ctx_texts, labels = retrieve(idx, chunks, emb, question, k=args.top_k)
+
+    if not ctx_texts:
+        print("I don't know based on the provided sources.")
+        return 0
+
+    try:
+        answer = generate_answer(client, question, ctx_texts)
+    except HTTPError as err:
+        message, hint = _format_hf_http_error(err)
+        print(message, file=sys.stderr)
+        if hint:
+            print(f"Hint: {hint}", file=sys.stderr)
+        return 5
+    except Exception as err:
+        print(f"Generation failed: {err}", file=sys.stderr)
+        return 6
+
+    print("Answer:\n")
+    print(answer)
+    print()
+    _print_sources(labels)
+
+    if args.show_context:
+        _print_context(ctx_texts, labels)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build_index.py
+++ b/build_index.py
@@ -1,0 +1,86 @@
+import os, json
+from typing import List, Dict
+import numpy as np
+from sentence_transformers import SentenceTransformer
+from pypdf import PdfReader
+import faiss
+from tqdm import tqdm
+
+DOCS_DIR = "docs"
+OUT_DIR = "index"
+EMBED_MODEL = "intfloat/e5-small-v2"
+
+CHUNK_WORDS = 180
+OVERLAP_WORDS = 40
+
+def read_txt(path: str) -> List[Dict]:
+    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+        text = f.read()
+    return [{"text": text, "meta": {"source": os.path.basename(path), "page": None}}]
+
+def read_pdf(path: str) -> List[Dict]:
+    reader = PdfReader(path)
+    out = []
+    for i, page in enumerate(reader.pages):
+        t = page.extract_text() or ""
+        out.append({"text": t, "meta": {"source": os.path.basename(path), "page": i+1}})
+    return out
+
+def chunk_words(text: str, size=CHUNK_WORDS, overlap=OVERLAP_WORDS):
+    words = text.split()
+    chunks = []
+    i = 0
+    while i < len(words):
+        piece = " ".join(words[i:i+size]).strip()
+        if piece:
+            chunks.append(piece)
+        i += max(1, size - overlap)
+    return chunks
+
+def main():
+    os.makedirs(OUT_DIR, exist_ok=True)
+    model = SentenceTransformer(EMBED_MODEL)
+
+    all_chunks = []
+    if not os.path.isdir(DOCS_DIR):
+        print(f"Missing folder: {DOCS_DIR}")
+        return
+
+    fnames = [f for f in os.listdir(DOCS_DIR) if f.lower().endswith((".txt",".pdf"))]
+    if not fnames:
+        print(f"No .txt or .pdf files in {DOCS_DIR}. Add a small .txt to test.")
+        return
+
+    print(f"Scanning {DOCS_DIR} ...")
+    for fname in fnames:
+        path = os.path.join(DOCS_DIR, fname)
+        docs = read_txt(path) if fname.lower().endswith(".txt") else read_pdf(path)
+        for d in docs:
+            for c in chunk_words(d["text"]):
+                all_chunks.append({
+                    "text": c,
+                    "source": d["meta"]["source"],
+                    "page": d["meta"]["page"]
+                })
+
+    if not all_chunks:
+        print("No chunks produced (PDFs might be scanned images). Try a .txt first.")
+        return
+
+    print(f"Embedding {len(all_chunks)} chunks ...")
+    texts = [c["text"] for c in all_chunks]
+    embs = model.encode([f"passage: {t}" for t in texts],
+                        normalize_embeddings=True, batch_size=64)
+    embs = np.asarray(embs, dtype="float32")
+
+    index = faiss.IndexFlatIP(embs.shape[1])
+    index.add(embs)
+
+    faiss.write_index(index, os.path.join(OUT_DIR, "faiss.index"))
+    with open(os.path.join(OUT_DIR, "chunks.json"), "w", encoding="utf-8") as f:
+        json.dump(all_chunks, f, ensure_ascii=False, indent=2)
+
+    print("Index built ✅  Files saved to index/")
+
+if __name__ == "__main__":
+    main()

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -1,0 +1,3 @@
+Put your .txt and .pdf documents in this folder.
+For your first test, create a small file like "topic.txt" with a few sentences.
+Then run:  python build_index.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+streamlit
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+sentence-transformers
+faiss-cpu
+pypdf
+numpy
+tqdm
+huggingface-hub
+python-dotenv


### PR DESCRIPTION
## Summary
- add targeted Hugging Face HTTP error reporting with remediation hints in the RAG app
- filter invalid FAISS hits and tighten type hints during retrieval
- document how to resolve 404 errors when overriding the hosted model and how to validate environment variables
- fall back to Hugging Face chat completions when a model does not support text-generation
- replace the Streamlit front end with a CLI-focused debug workflow and refresh the README with debugging instructions
- streamline the README for macOS-only local usage and remove online deployment steps

## Testing
- python -m compileall app.py build_index.py

------
https://chatgpt.com/codex/tasks/task_e_68e41d161200832ab792e4232c0ddf72